### PR TITLE
Add encoding info to source

### DIFF
--- a/ADC_function.py
+++ b/ADC_function.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import requests
 from configparser import ConfigParser
 import os

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import glob
 import os
 import time

--- a/core.py
+++ b/core.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import re
 import os
 import os.path


### PR DESCRIPTION
According to PEP-263, add encoding info to source code. Or there would be errors report at runtime under linux.