### PR TITLE
全局变量，排除指定目录，fanza

### DIFF
--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -6,24 +6,14 @@ import os
 import time
 import re
 from ADC_function import *
+from core import *
 import json
 import shutil
 import fnmatch
 from configparser import ConfigParser
-os.chdir(os.getcwd())
 
-# ============global var===========
 
-version='2.3'
-
-config = ConfigParser()
-config.read(config_file, encoding='UTF-8')
-
-Platform = sys.platform
-
-# ==========global var end=========
-
-def UpdateCheck():
+def UpdateCheck(version):
     if UpdateCheckSwitch() == '1':
         html2 = get_html('https://raw.githubusercontent.com/yoshiko2/AV_Data_Capture/master/update_check.json')
         html = json.loads(str(html2))
@@ -35,33 +25,39 @@ def UpdateCheck():
             print('[*]======================================================')
     else:
         print('[+]Update Check disabled!')
-def movie_lists():
-    global exclude_directory_1
-    global exclude_directory_2
-    total=[]
-    file_type = ['.mp4','.avi','.rmvb','.wmv','.mov','.mkv','.flv','.ts','.MP4', '.AVI', '.RMVB', '.WMV', '.MOV', '.MKV', '.FLV', '.TS',]
-    exclude_directory_1 = config['common']['failed_output_folder']
-    exclude_directory_2 = config['common']['success_output_folder']
-    file_root=os.getcwd()
-    for root,dirs,files in os.walk(file_root):
-        if exclude_directory_1 not in root and exclude_directory_2 not in root:
-            for f in files:
-                if os.path.splitext(f)[1] in file_type:
-                    path = os.path.join(root,f)
-                    path = path.replace(file_root,'.')
-                    total.append(path)
+
+
+def movie_lists(escape_folder):
+    escape_folder = re.split('[,，]', escape_folder)
+    total = []
+    file_type = ['.mp4', '.avi', '.rmvb', '.wmv', '.mov', '.mkv', '.flv', '.ts', '.MP4', '.AVI', '.RMVB', '.WMV',
+                 '.MOV', '.MKV', '.FLV', '.TS', ]
+    file_root = os.getcwd()
+    for root, dirs, files in os.walk(file_root):
+        flag_escape = 0
+        for folder in escape_folder:
+            if folder in root:
+                flag_escape = 1
+                break
+        if flag_escape == 1:
+            continue
+        for f in files:
+            if os.path.splitext(f)[1] in file_type:
+                path = os.path.join(root, f)
+                path = path.replace(file_root, '.')
+                total.append(path)
     return total
-def CreatFailedFolder():
-    if not os.path.exists('failed/'):  # 新建failed文件夹
+
+
+def CreatFailedFolder(failed_folder):
+    if not os.path.exists(failed_folder + '/'):  # 新建failed文件夹
         try:
-            os.makedirs('failed/')
+            os.makedirs(failed_folder + '/')
         except:
             print("[-]failed!can not be make folder 'failed'\n[-](Please run as Administrator)")
             os._exit(0)
-def lists_from_test(custom_nuber): #电影列表
-    a=[]
-    a.append(custom_nuber)
-    return a
+
+
 def CEF(path):
     try:
         files = os.listdir(path)  # 获取路径下的子文件(夹)列表
@@ -69,21 +65,17 @@ def CEF(path):
             os.removedirs(path + '/' + file)  # 删除这个空文件夹
             print('[+]Deleting empty folder', path + '/' + file)
     except:
-        a=''
-def rreplace(self, old, new, *max):
-#从右开始替换文件名中内容，源字符串，将被替换的子字符串， 新字符串，用于替换old子字符串，可选字符串, 替换不超过 max 次
-    count = len(self)
-    if max and str(max[0]).isdigit():
-        count = max[0]
-    return new.join(self.rsplit(old, count))
+        a = ''
+
+
 def getNumber(filepath):
-    filepath = filepath.replace('.\\','')
+    filepath = filepath.replace('.\\', '')
     if '-' in filepath or '_' in filepath:  # 普通提取番号 主要处理包含减号-和_的番号
         filepath = filepath.replace("_", "-")
         filepath.strip('22-sht.me').strip('-HD').strip('-hd')
         filename = str(re.sub("\[\d{4}-\d{1,2}-\d{1,2}\] - ", "", filepath))  # 去除文件名中时间
         if 'FC2' or 'fc2' in filename:
-            filename=filename.replace('-PPV','').replace('PPV-','')
+            filename = filename.replace('-PPV', '').replace('PPV-', '')
         try:
             file_number = re.search('\w+-\d+', filename).group()
         except:  # 提取类似mkbd-s120番号
@@ -91,63 +83,54 @@ def getNumber(filepath):
         return file_number
     else:  # 提取不含减号-的番号，FANZA CID
         try:
-            return str(re.findall(r'(.+?)\.', str(re.search('([^<>/\\\\|:""\\*\\?]+)\\.\\w+$', filepath).group()))).strip("['']").replace('_', '-')
+            return str(
+                re.findall(r'(.+?)\.', str(re.search('([^<>/\\\\|:""\\*\\?]+)\\.\\w+$', filepath).group()))).strip(
+                "['']").replace('_', '-')
         except:
-            return re.search(r'(.+?)\.',filepath)[0]
+            return re.search(r'(.+?)\.', filepath)[0]
 
-def RunCore():
-    if Platform == 'win32':
-        if os.path.exists('core.py'):
-            os.system('python core.py' + '   "' + i + '" --number "' + getNumber(i) + '"')  # 从py文件启动（用于源码py）
-        elif os.path.exists('core.exe'):
-            os.system('core.exe' + '   "' + i + '" --number "' + getNumber(i) + '"')  # 从exe启动（用于EXE版程序）
-        elif os.path.exists('core.py') and os.path.exists('core.exe'):
-            os.system('python core.py' + '   "' + i + '" --number "' + getNumber(i) + '"')  # 从py文件启动（用于源码py）
-    else:
-        if os.path.exists('core.py'):
-            try:
-                os.system('python3 core.py' + '   "' + i + '" --number "' + getNumber(i) + '"')  # 从py文件启动（用于源码py）
-            except:
-                os.system('python core.py' + '   "' + i + '" --number "' + getNumber(i) + '"')  # 从py文件启动（用于源码py）
-        elif os.path.exists('core.exe'):
-            os.system('core.exe' + '   "' + i + '" --number "' + getNumber(i) + '"')  # 从exe启动（用于EXE版程序）
-        elif os.path.exists('core.py') and os.path.exists('core.exe'):
-            os.system('python3 core.py' + '   "' + i + '" --number "' + getNumber(i) + '"')  # 从py文件启动（用于源码py）
 
-if __name__ =='__main__':
+if __name__ == '__main__':
+    version = '2.3'
+    config_file = 'config.ini'
+    config = ConfigParser()
+    config.read(config_file, encoding='UTF-8')
+    success_folder = config['common']['success_output_folder']
+    failed_folder = config['common']['failed_output_folder']  # 失败输出目录
+    escape_folder = config['escape']['folders']  # 多级目录刮削需要排除的目录
     print('[*]================== AV Data Capture ===================')
-    print('[*]                     Version '+version)
+    print('[*]                     Version ' + version)
     print('[*]======================================================')
 
-    CreatFailedFolder()
-    UpdateCheck()
+    UpdateCheck(version)
+    CreatFailedFolder(failed_folder)
     os.chdir(os.getcwd())
-    movie_list=movie_lists()
+    movie_list = movie_lists(escape_folder)
 
     count = 0
     count_all = str(len(movie_list))
-    print('[+]Find',count_all,'movies')
+    print('[+]Find', count_all, 'movies')
     if config['common']['soft_link'] == '1':
         print('[!] --- Soft link mode is ENABLE! ----')
-    for i in movie_list: #遍历电影列表 交给core处理
+    for i in movie_list:  # 遍历电影列表 交给core处理
         count = count + 1
-        percentage = str(count/int(count_all)*100)[:4]+'%'
-        print('[!] - '+percentage+' ['+str(count)+'/'+count_all+'] -')
+        percentage = str(count / int(count_all) * 100)[:4] + '%'
+        print('[!] - ' + percentage + ' [' + str(count) + '/' + count_all + '] -')
         try:
             print("[!]Making Data for   [" + i + "], the number is [" + getNumber(i) + "]")
-            RunCore()
+            core_main(i, getNumber(i))
             print("[*]======================================================")
         except:  # 番号提取异常
             print('[-]' + i + ' Cannot catch the number :')
             if config['common']['soft_link'] == '1':
-                print('[-]Link',i,'to failed folder')
-                os.symlink(i,str(os.getcwd()) + '/' + 'failed/')
+                print('[-]Link', i, 'to failed folder')
+                os.symlink(i, str(os.getcwd()) + '/' + 'failed/')
             else:
                 print('[-]Move ' + i + ' to failed folder')
                 shutil.move(i, str(os.getcwd()) + '/' + 'failed/')
             continue
 
-    CEF(exclude_directory_1)
-    CEF(exclude_directory_2)
+    CEF(success_folder)
+    CEF(failed_folder)
     print("[+]All finished!!!")
     input("[+][+]Press enter key exit, you can check the error messge before you exit.")

--- a/README.md
+++ b/README.md
@@ -159,18 +159,12 @@ pip install pillow
 如果是PLEX，请安装插件：```XBMCnfoMoviesImporter```
 
 ---
-### 抓取目录
+### 排除指定字符和目录
 >[escape]  
 >literals=\  
-
+>folders=failed,JAV_output
 ```literals=``` 标题指定字符删除，例如```iterals=\()```，删除标题中```\()```字符
-
----
-### 抓取目录选择
->[movie_location]<br>
->path=<br>
-
-如果directory后面为空，则抓取和程序同一目录下的影片
+```folders=``` 排指定目录，例如```folders=failed,JAV_output```，多目录刮削时跳过failed,JAV_output
 
 ---
 ### 调试模式

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ pip install pillow
 ### 排除指定字符和目录
 >[escape]  
 >literals=\  
->folders=failed,JAV_output
-```literals=``` 标题指定字符删除，例如```iterals=\()```，删除标题中```\()```字符
-```folders=``` 排指定目录，例如```folders=failed,JAV_output```，多目录刮削时跳过failed,JAV_output
+>folders=failed,JAV_output  
+```literals=``` 标题指定字符删除，例如```iterals=\()```，删除标题中```\()```字符  
+```folders=``` 排指定目录，例如```folders=failed,JAV_output```，多目录刮削时跳过failed,JAV_output  
 
 ---
 ### 调试模式

--- a/config.ini
+++ b/config.ini
@@ -22,6 +22,7 @@ media_warehouse=emby
 
 [escape]
 literals=\()
+folders=failed,JAV_output
 
 [debug_mode]
 switch=0

--- a/fanza.py
+++ b/fanza.py
@@ -82,24 +82,29 @@ def main(number):
     if '404 Not Found' in htmlcode:
         htmlcode=get_html('https://www.dmm.co.jp/mono/dvd/-/detail/=/cid='+number)
         url = 'https://www.dmm.co.jp/mono/dvd/-/detail/=/cid='+number
-    dic = {
-        'title': getTitle(htmlcode).strip(getActor(htmlcode)),
-        'studio': getStudio(htmlcode),
-        'outline': getOutline(htmlcode),
-        'runtime': getRuntime(htmlcode),
-        'director': getDirector(htmlcode),
-        'actor': getActor(htmlcode),
-        'release': getRelease(htmlcode),
-        'number': getNum(htmlcode),
-        'cover': getCover(htmlcode,number),
-        'imagecut': 1,
-        'tag': getTag(htmlcode),
-        'label':getLabel(htmlcode),
-        'year': getYear(getRelease(htmlcode)),  # str(re.search('\d{4}',getRelease(a)).group()),
-        'actor_photo': '',
-        'website': url,
-        'source': 'siro.py',
-    }
+    try:
+        dic = {
+            'title': getTitle(htmlcode).strip(getActor(htmlcode)),
+            'studio': getStudio(htmlcode),
+            'outline': getOutline(htmlcode),
+            'runtime': getRuntime(htmlcode),
+            'director': getDirector(htmlcode),
+            'actor': getActor(htmlcode),
+            'release': getRelease(htmlcode),
+            'number': getNum(htmlcode),
+            'cover': getCover(htmlcode,number),
+            'imagecut': 1,
+            'tag': getTag(htmlcode),
+            'label':getLabel(htmlcode),
+            'year': getYear(getRelease(htmlcode)),  # str(re.search('\d{4}',getRelease(a)).group()),
+            'actor_photo': '',
+            'website': url,
+            'source': 'siro.py',
+        }
+    except :
+        dic = {
+            'title': '',
+        }
     js = json.dumps(dic, ensure_ascii=False, sort_keys=True, indent=4, separators=(',', ':'))  # .encode('UTF-8')
     return js
 


### PR DESCRIPTION
1、改AV_Data_Capture.py,core.py中所有的全局变量为函数参数。
2、修复fanza.py，‘n1180.mp4’这类影片导致的数组越界。
3、添加排除目录，多层目录刮削时，排除自定义的目录。默认为folders=failed,JAV_output。