### PR TITLE
Add github actions to build executable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: PyInstaller
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: add-github-actions
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+
+    - name: Build with pyinstaller
+      run: |
+        pyinstaller --onefile AV_Data_Capture.py
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: AV_Data_Capture-${{ matrix.os }}
+        path: dist

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+pyquery
+lxml
+beautifulsoup4
+pillow
+pyinstaller

--- a/ruquirments.txt
+++ b/ruquirments.txt
@@ -1,4 +1,0 @@
-lxml
-bs4
-pillow
-pyquery


### PR DESCRIPTION
Create an executable file for Windows/macOS/Ubuntu.
Actions triggered by push to master branch and pull request.

Created executable file can be downloaded from the job result page.
(`config.ini` is not included.)

### Example job

- triggered by push to master: https://github.com/68cdrBxM8YdoJ/AV_Data_Capture/actions/runs/72685177

- triggered by pull request
https://github.com/68cdrBxM8YdoJ/AV_Data_Capture/actions/runs/72684562