### PR TITLE
Bundle config.ini to artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,10 @@ jobs:
     - name: Build with pyinstaller
       run: |
         pyinstaller --onefile AV_Data_Capture.py  --hidden-import ADC_function.py --hidden-import core.py
-      
-    - name : Write config file
+
+    - name: Copy config.ini
       run: |
-        wget -o config.ini https://raw.githubusercontent.com/yoshiko2/AV_Data_Capture/master/config.ini
+        cp config.ini dist/
 
     - name: Upload build artifact
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
It seems that the `wget` command is not available for windows containers.
(https://github.com/yoshiko2/AV_Data_Capture/runs/578860913)

Use `cp` instead of `wget`.