### PR TITLE
修复更新 API 超限时闪退问题

### DIFF
--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -9,7 +9,7 @@ def check_update(local_version):
     try:
         remote = float(data["tag_name"])
         local = float(local_version)
-    except ValueError:
+    except:
         print("[-] Check update failed! Skipped.")
         return
 


### PR DESCRIPTION
API超限时候数据为
```
{
"message": "API rate limit exceeded for 23.99.110.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
"documentation_url": "https://developer.github.com/v3/#rate-limiting"
}
```
然后因为找不到 `tag_name` 报错
```
Traceback (most recent call last):
  File ".\AV_Data_Capture.py", line 108, in <module>
    check_update(version)
  File ".\AV_Data_Capture.py", line 10, in check_update
    remote = float(data["tag_name"])
KeyError: 'tag_name'
```