### PR TITLE
add socks5h proxy support

### DIFF
--- a/ADC_function.py
+++ b/ADC_function.py
@@ -3,6 +3,7 @@ from lxml import etree
 
 import config
 
+SUPPORT_PROXY_TYPE = ("http", "socks5", "socks5h")
 
 def get_data_state(data: dict) -> bool:  # 元数据获取失败检测
     if "title" not in data or "number" not in data:
@@ -27,8 +28,8 @@ def get_proxy(proxy: str, proxytype: str = None) -> dict:
     ''' 获得代理参数，默认http代理
     '''
     if proxy:
-        if proxytype.startswith("socks"):
-            proxies = {"http": "socks5://" + proxy, "https": "socks5://" + proxy}
+        if proxytype in SUPPORT_PROXY_TYPE:
+            proxies = {"http": proxytype + "://" + proxy, "https": proxytype + "://" + proxy}
         else:
             proxies = {"http": "http://" + proxy, "https": "https://" + proxy}
     else:

--- a/config.ini
+++ b/config.ini
@@ -5,7 +5,7 @@ success_output_folder=JAV_output
 soft_link=0
 
 [proxy]
-;proxytype: http or socks5
+;proxytype: http or socks5 or socks5h
 type=http
 proxy=127.0.0.1:1080
 timeout=10


### PR DESCRIPTION
Support `socks5h` proxy to prevent DNS pollution
>Using the scheme `socks5` causes the DNS resolution to happen on the client, rather than on the proxy server. This is in line with curl, which uses the scheme to decide whether to do the DNS resolution on the client or proxy. If you want to resolve the domains on the proxy server, use `socks5h` as the scheme.

Reference: [https://requests.readthedocs.io/en/master/user/advanced/#socks](https://requests.readthedocs.io/en/master/user/advanced/#socks)