### PR TITLE
修正 AVSOX 重定向到发布页的问题

### DIFF
--- a/WebCrawler/avsox.py
+++ b/WebCrawler/avsox.py
@@ -83,15 +83,17 @@ def getSeries(htmlcode):
         return ''
 
 def main(number):
-    a = get_html('https://avsox.host/cn/search/' + number)
+    html = get_html('https://tellme.pw/avsox')
+    site = etree.HTML(html).xpath('//div[@class="container"]/div/a/@href')[0]
+    a = get_html(site + '/cn/search/' + number)
     html = etree.fromstring(a, etree.HTMLParser())  # //table/tr[1]/td[1]/text()
     result1 = str(html.xpath('//*[@id="waterfall"]/div/a/@href')).strip(" ['']")
     if result1 == '' or result1 == 'null' or result1 == 'None':
-        a = get_html('https://avsox.host/cn/search/' + number.replace('-', '_'))
+        a = get_html(site + '/cn/search/' + number.replace('-', '_'))
         html = etree.fromstring(a, etree.HTMLParser())  # //table/tr[1]/td[1]/text()
         result1 = str(html.xpath('//*[@id="waterfall"]/div/a/@href')).strip(" ['']")
         if result1 == '' or result1 == 'null' or result1 == 'None':
-            a = get_html('https://avsox.host/cn/search/' + number.replace('_', ''))
+            a = get_html(site + '/cn/search/' + number.replace('_', ''))
             html = etree.fromstring(a, etree.HTMLParser())  # //table/tr[1]/td[1]/text()
             result1 = str(html.xpath('//*[@id="waterfall"]/div/a/@href')).strip(" ['']")
     web = get_html(result1)


### PR DESCRIPTION
AVSOX 硬编码的地址有时候会 302 跳转到发布页，不如直接从发布页获取最新地址。