### PR TITLE
修正剥削网站不存在的问题

### DIFF
--- a/core.py
+++ b/core.py
@@ -65,18 +65,20 @@ def get_data_from_json(file_number, filepath, conf: config.Config):  # ä»ŽJSONè¿
 
     # if the input file name matches certain rules,
     # move some web service to the beginning of the list
-    if re.match(r"^\d{5,}", file_number) or (
+    if "avsox" in sources and (re.match(r"^\d{5,}", file_number) or
         "HEYZO" in file_number or "heyzo" in file_number or "Heyzo" in file_number
     ):
         sources.insert(0, sources.pop(sources.index("avsox")))
-    elif re.match(r"\d+\D+", file_number) or (
+    elif "fanza" in sources and (re.match(r"\d+\D+", file_number) or
         "siro" in file_number or "SIRO" in file_number or "Siro" in file_number
     ):
         sources.insert(0, sources.pop(sources.index("fanza")))
-    elif "fc2" in file_number or "FC2" in file_number:
+    elif "fc2" in sources and ("fc2" in file_number or "FC2" in file_number
+    ):
         sources.insert(0, sources.pop(sources.index("fc2")))
-
-    elif "RJ" in file_number or "rj" or "VJ" or "vj" in file_number:
+    elif "dlsite" in sources and (
+        "RJ" in file_number or "rj" in file_number or "VJ" in file_number or "vj" in file_number
+    ):
         sources.insert(0, sources.pop(sources.index("dlsite")))
 
     json_data = {}


### PR DESCRIPTION
如果从配置文件中剔除了某个网站，匹配到规则的网站无法重新排序。