### PR TITLE
修复字幕文件无法自动移动，修复javbus类别标签抓取时多出的 “多選提交”

### DIFF
--- a/WebCrawler/javbus.py
+++ b/WebCrawler/javbus.py
@@ -103,7 +103,7 @@ def getTag(htmlcode):  # 获取标签
     soup = BeautifulSoup(htmlcode, 'lxml')
     a = soup.find_all(attrs={'class': 'genre'})
     for i in a:
-        if 'onmouseout' in str(i):
+        if 'onmouseout' in str(i) or '多選提交' in str(i):
             continue
         tag.append(translateTag_to_sc(i.get_text()))
     return tag

--- a/core.py
+++ b/core.py
@@ -612,8 +612,8 @@ def paste_file_to_folder(filepath, path, number, leak_word, c_word, conf: config
         sub_res = conf.sub_rule()
 
         for subname in sub_res:
-            if os.path.exists(number + leak_word + c_word + subname):  # 字幕移动
-                os.rename(number + leak_word + c_word + subname, path + '/' + number + leak_word + c_word + subname)
+            if os.path.exists(filepath.replace(houzhui, subname)):  # 字幕移动
+                os.rename(filepath.replace(houzhui, subname), path + '/' + number + leak_word + c_word + subname)
                 print('[+]Sub moved!')
                 return True
         
@@ -639,8 +639,8 @@ def paste_file_to_folder_mode2(filepath, path, multi_part, number, part, leak_wo
         
         sub_res = conf.sub_rule()
         for subname in sub_res:
-            if os.path.exists(os.getcwd() + '/' + number + leak_word + c_word + subname):  # 字幕移动
-                os.rename(os.getcwd() + '/' + number + leak_word + c_word + subname, path + '/' + number + leak_word + c_word + subname)
+            if os.path.exists(filepath.replace(houzhui, subname)):  # 字幕移动
+                os.rename(filepath.replace(houzhui, subname), path + '/' + number + leak_word + c_word + subname)
                 print('[+]Sub moved!')
                 print('[!]Success')
                 return True


### PR DESCRIPTION
1.修复字幕文件无法自动移动；
2.修复javbus类别标签抓取时多出的 “多選提交”