### PR TITLE
Use large image as cover in mgstage

### DIFF
--- a/WebCrawler/mgstage.py
+++ b/WebCrawler/mgstage.py
@@ -75,6 +75,7 @@ def getTag(a):
 def getCover(htmlcode):
     html = etree.fromstring(htmlcode, etree.HTMLParser())
     result = str(html.xpath('//*[@id="center_column"]/div[1]/div[1]/div/div/h2/img/@src')).strip(" ['']")
+    result = str(html.xpath('//*[@id="EnlargeImage"]/@href')).strip(" ['']")
     #                    /html/body/div[2]/article[2]/div[1]/div[1]/div/div/h2/img/@src
     return result
 def getDirector(a):


### PR DESCRIPTION
Currently, in the mgstage parser, the image from the website is used. However, a high-res and large image is available from the "enlarge" option. This pull request replaces the cover to the high-res variant.

Here is a concrete example for: 300MIUM-526

| Old (small image) | New (high-res) | 
|--|--|
|![](https://image.mgstage.com/images/prestigepremium/300mium/526/pf_o1_300mium-526.jpg) | ![](https://image.mgstage.com/images/prestigepremium/300mium/526/pb_e_300mium-526.jpg) |

As a side effect, it also makes the scraping result more consistent with other scrapers such as javbus.