### PR TITLE
fix empty number cause prog stop, failed symlink not create on windows

### DIFF
--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -80,17 +80,24 @@ def rm_empty_folder(path):
 
 def create_data_and_move(file_path: str, c: config.Config, debug):
     # Normalized number, eg: 111xxx-222.mp4 -> xxx-222.mp4
-    n_number = get_number(debug, os.path.basename(file_path))
+    file_name = os.path.basename(file_path)
+    n_number = get_number(debug, file_name)
     file_path = os.path.abspath(file_path)
 
     if debug == True:
         print("[!]Making Data for [{}], the number is [{}]".format(file_path, n_number))
-        core_main(file_path, n_number, c)
+        if n_number:
+            core_main(file_path, n_number, c)
+        else:
+            print("[-] number empty ERROR")
         print("[*]======================================================")
     else:
         try:
             print("[!]Making Data for [{}], the number is [{}]".format(file_path, n_number))
-            core_main(file_path, n_number, c)
+            if n_number:
+                core_main(file_path, n_number, c)
+            else:
+                raise ValueError("number empty")
             print("[*]======================================================")
         except Exception as err:
             print("[-] [{}] ERROR:".format(file_path))
@@ -100,11 +107,11 @@ def create_data_and_move(file_path: str, c: config.Config, debug):
             if c.failed_move() == False:
                 if c.soft_link():
                     print("[-]Link {} to failed folder".format(file_path))
-                    os.symlink(file_path, conf.failed_folder() + "/")
+                    os.symlink(file_path, conf.failed_folder() + "/" + file_name)
             elif c.failed_move() == True:
                 if c.soft_link():
                     print("[-]Link {} to failed folder".format(file_path))
-                    os.symlink(file_path, conf.failed_folder() + "/")
+                    os.symlink(file_path, conf.failed_folder() + "/" + file_name)
                 else:
                     try:
                         print("[-]Move [{}] to failed folder".format(file_path))

--- a/number_parser.py
+++ b/number_parser.py
@@ -46,6 +46,8 @@ def get_number(debug,filepath: str) -> str:
                     file_number = str(re.search(r'\d{6}(-|_)\d{3}', lower_check, re.A).group()).replace('_', '-')
                 elif "1pon" in lower_check:
                     file_number = str(re.search(r'\d{6}(-|_)\d{3}', lower_check, re.A).group()).replace('-', '_')
+                elif "10mu" in lower_check:
+                    file_number = str(re.search(r'\d{6}(-|_)\d{2}', lower_check, re.A).group()).replace('-', '_')
                 return file_number
             else:  # 提取不含减号-的番号，FANZA CID
                 # 欧美番号匹配规则
@@ -78,6 +80,8 @@ def get_number(debug,filepath: str) -> str:
                 file_number = str(re.search(r'\d{6}(-|_)\d{3}', lower_check, re.A).group()).replace('_', '-')
             elif "1pon" in lower_check:
                 file_number = str(re.search(r'\d{6}(-|_)\d{3}', lower_check, re.A).group()).replace('-', '_')
+            elif "10mu" in lower_check:
+                file_number = str(re.search(r'\d{6}(-|_)\d{2}', lower_check, re.A).group()).replace('-', '_')
             return file_number
         else:  # 提取不含减号-的番号，FANZA CID
             # 欧美番号匹配规则


### PR DESCRIPTION
修复当目标目录中有"某某网站-欢迎你.mp4"之类视频时，会得到空number，导致程序因双重异常，停止运行，必须处理后重头再来的问题。在整理上千个视频时，这种程序退出会很头疼，非常耽误时间。
修复在Windows平台下，failed目录从未生成指向分析失败的文件的软链接，os.symlink参数补全软链接文件名，Windows平台下不能将之省略。