### PR TITLE
BUG修复

### DIFF
--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -11,6 +11,9 @@ from ADC_function import get_html
 from number_parser import get_number
 from core import core_main
 
+import urllib3
+urllib3.disable_warnings() #disable these warnings
+
 
 def check_update(local_version):
     try:

--- a/core.py
+++ b/core.py
@@ -35,12 +35,12 @@ def escape_path(path, escape_literals: str):  # Remove escape literals
 
 def moveFailedFolder(filepath, failed_folder):
     if config.Config().failed_move():
-        root_path = str(pathlib.Path(filepath).parent)
+        root_path = os.getcwd()
         file_name = pathlib.Path(filepath).name
-        destination_path = root_path + '/' + failed_folder + '/'
+        destination_path = root_path + '\\' + failed_folder + '\\'
         if config.Config().soft_link():
             print('[-]Create symlink to Failed output folder')
-            os.symlink(filepath, destination_path + '/' + file_name)
+            os.symlink(filepath, destination_path + file_name)
         else:
             print('[-]Move to Failed output folder')
             shutil.move(filepath, destination_path)
@@ -424,13 +424,13 @@ def trailer_download(trailer, leak_word, c_word, number, path, filepath, conf: c
         return
     print('[+]Video Downloaded!', path + '/' + number + leak_word + c_word + '-trailer.mp4')
 
-# 剧照下载成功，否则移动到failed
+# 剧照下载成功，#否则移动到failed--取消
 def extrafanart_download(data, path, conf: config.Config, filepath, failed_folder):
     j = 1
     path = path + '/' + conf.get_extrafanart()
     for url in data:
         if download_file_with_filename(url, '/extrafanart-' + str(j)+'.jpg', path, conf, filepath, failed_folder) == 'failed':
-            moveFailedFolder(filepath, failed_folder)
+            #moveFailedFolder(filepath, failed_folder)
             return
         switch, _proxy, _timeout, retry, _proxytype = conf.proxy()
         for i in range(retry):


### PR DESCRIPTION
1.禁用未经验证的HTTPS证书警告
2.修复爬取数据失败的文件移动路径错误导致的文件名被改为failed并覆盖之前文件的BUG
3.取消剧照下载失败移动到failed文件夹