### PR TITLE
video files must be regular files, links will be ignored

### DIFF
--- a/ADC_function.py
+++ b/ADC_function.py
@@ -2,6 +2,7 @@ import requests
 import hashlib
 import pathlib
 import random
+import os.path
 import uuid
 import json
 import time
@@ -567,3 +568,11 @@ def file_modification_days(filename) -> int:
     if days < 0:
         return 9999
     return days
+
+# 检查文件是否是链接
+def is_link(filename: str):
+    if os.path.islink(filename):
+        return True # symlink
+    elif os.stat(filename).st_nlink > 1:
+        return True # hard link Linux MAC OSX Windows NTFS
+    return False

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -56,7 +56,7 @@ def movie_lists(root, escape_folder):
             total += movie_lists(f, escape_folder)
         elif os.path.splitext(f)[1].upper() in file_type:
             absf = os.path.abspath(f)
-            if not is_link(absf):
+            if conf.main_mode() == 3 or not is_link(absf):
                 total.append(absf)
     return total
 

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -8,7 +8,7 @@ import urllib3
 
 import config
 import time
-from ADC_function import get_html
+from ADC_function import get_html, is_link
 from number_parser import get_number
 from core import core_main
 
@@ -44,7 +44,6 @@ def argparse_function(ver: str) -> [str, str, bool]:
 
     return args.file, args.path, args.number, args.autoexit
 
-
 def movie_lists(root, escape_folder):
     if os.path.basename(root) in escape_folder:
         return []
@@ -56,7 +55,9 @@ def movie_lists(root, escape_folder):
         if os.path.isdir(f):
             total += movie_lists(f, escape_folder)
         elif os.path.splitext(f)[1].upper() in file_type:
-            total.append(os.path.abspath(f))
+            absf = os.path.abspath(f)
+            if not is_link(absf):
+                total.append(absf)
     return total
 
 


### PR DESCRIPTION
彻底解决 https://github.com/yoshiko2/AV_Data_Capture/discussions/459 再次削刮软链接的问题。
以及将目标软链接转换为硬链接后，重复削刮由常规文件变为硬链接的对端源视频文件的问题。
模式3不移动视频文件，可以豁免此限制，以便进行元数据更新。