### PR TITLE
core.py:moveFailedFolder() just the same action as in AV_Data_Capture.py

### DIFF
--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -120,12 +120,13 @@ def create_data_and_move(file_path: str, c: config.Config, debug):
                 else:
                     try:
                         print("[-]Move [{}] to failed folder".format(file_path))
-                        shutil.move(file_path, conf.failed_folder() + "/")
+                        shutil.move(file_path, conf.failed_folder() + "/" + file_name)
                     except Exception as err:
                         print('[!]', err)
 
 
 def create_data_and_move_with_custom_number(file_path: str, c: config.Config, custom_number):
+    file_name = os.path.basename(file_path)
     try:
         print("[!]Making Data for [{}], the number is [{}]".format(file_path, custom_number))
         core_main(file_path, custom_number, c)
@@ -136,11 +137,11 @@ def create_data_and_move_with_custom_number(file_path: str, c: config.Config, cu
 
         if c.soft_link():
             print("[-]Link {} to failed folder".format(file_path))
-            os.symlink(file_path, conf.failed_folder() + "/")
+            os.symlink(file_path, conf.failed_folder() + "/" + file_name)
         else:
             try:
                 print("[-]Move [{}] to failed folder".format(file_path))
-                shutil.move(file_path, conf.failed_folder() + "/")
+                shutil.move(file_path, conf.failed_folder() + "/" + file_name)
             except Exception as err:
                 print('[!]', err)
 

--- a/core.py
+++ b/core.py
@@ -36,10 +36,11 @@ def escape_path(path, escape_literals: str):  # Remove escape literals
 
 
 def moveFailedFolder(filepath):
-    if config.Config().failed_move():
-        failed_folder = config.Config().failed_folder()
+    conf = config.Config()
+    if conf.failed_move():
+        failed_folder = conf.failed_folder()
         file_name = os.path.basename(filepath)
-        if config.Config().soft_link():
+        if conf.soft_link():
             print('[-]Create symlink to Failed output folder')
             os.symlink(filepath, failed_folder + '/' + file_name)
         else:

--- a/core.py
+++ b/core.py
@@ -35,17 +35,16 @@ def escape_path(path, escape_literals: str):  # Remove escape literals
     return path
 
 
-def moveFailedFolder(filepath, failed_folder):
+def moveFailedFolder(filepath):
     if config.Config().failed_move():
-        root_path = str(pathlib.Path(filepath).parent)
-        file_name = pathlib.Path(filepath).name
-        destination_path = root_path + '/' + failed_folder + '/'
+        failed_folder = config.Config().failed_folder()
+        file_name = os.path.basename(filepath)
         if config.Config().soft_link():
             print('[-]Create symlink to Failed output folder')
-            os.symlink(filepath, destination_path + '/' + file_name)
+            os.symlink(filepath, failed_folder + '/' + file_name)
         else:
             print('[-]Move to Failed output folder')
-            shutil.move(filepath, destination_path)
+            shutil.move(filepath, failed_folder + '/' + file_name)
     return
 
 
@@ -130,7 +129,7 @@ def get_data_from_json(file_number, filepath, conf: config.Config):  # 从JSON�
     # Return if data not found in all sources
     if not json_data:
         print('[-]Movie Data not found!')
-        moveFailedFolder(filepath, conf.failed_folder())
+        moveFailedFolder(filepath)
         return
 
     # ================================================网站规则添加结束================================================
@@ -169,7 +168,7 @@ def get_data_from_json(file_number, filepath, conf: config.Config):  # 从JSON�
 
     if title == '' or number == '':
         print('[-]Movie Data not found!')
-        moveFailedFolder(filepath, conf.failed_folder())
+        moveFailedFolder(filepath)
         return
 
     # if imagecut == '3':
@@ -395,7 +394,7 @@ def download_file_with_filename(url, filename, path, conf: config.Config, filepa
             i += 1
             print('[-]Image Download :  Connect retry ' + str(i) + '/' + str(configProxy.retry))
     print('[-]Connect Failed! Please check your Proxy or Network!')
-    moveFailedFolder(filepath, failed_folder)
+    moveFailedFolder(filepath)
     return
 
 def trailer_download(trailer, leak_word, c_word, number, path, filepath, conf: config.Config, failed_folder):
@@ -419,7 +418,7 @@ def extrafanart_download(data, path, conf: config.Config, filepath, failed_folde
     path = path + '/' + conf.get_extrafanart()
     for url in data:
         if download_file_with_filename(url, '/extrafanart-' + str(j)+'.jpg', path, conf, filepath, failed_folder) == 'failed':
-            moveFailedFolder(filepath, failed_folder)
+            moveFailedFolder(filepath)
             return
         configProxy = conf.proxy()
         for i in range(configProxy.retry):
@@ -440,7 +439,7 @@ def extrafanart_download(data, path, conf: config.Config, filepath, failed_folde
 # 封面是否下载成功，否则移动到failed
 def image_download(cover, number, leak_word, c_word, path, conf: config.Config, filepath, failed_folder):
     if download_file_with_filename(cover, number + leak_word + c_word + '-fanart.jpg', path, conf, filepath, failed_folder) == 'failed':
-        moveFailedFolder(filepath, failed_folder)
+        moveFailedFolder(filepath)
         return
 
     configProxy = conf.proxy()
@@ -522,12 +521,12 @@ def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, f
     except IOError as e:
         print("[-]Write Failed!")
         print(e)
-        moveFailedFolder(filepath, failed_folder)
+        moveFailedFolder(filepath)
         return
     except Exception as e1:
         print(e1)
         print("[-]Write Failed!")
-        moveFailedFolder(filepath, failed_folder)
+        moveFailedFolder(filepath)
         return
 
 
@@ -704,7 +703,7 @@ def get_part(filepath, failed_folder):
             return re.findall('-cd\d+', filepath)[0]
     except:
         print("[-]failed!Please rename the filename again!")
-        moveFailedFolder(filepath, failed_folder)
+        moveFailedFolder(filepath)
         return
 
 

--- a/core.py
+++ b/core.py
@@ -315,8 +315,8 @@ def get_info(json_data):  # 返回json里的数据
     return title, studio, year, outline, runtime, director, actor_photo, release, number, cover, trailer, website, series, label
 
 
-def small_cover_check(path, number, cover_small, leak_word, c_word, conf: config.Config, filepath, failed_folder):
-    download_file_with_filename(cover_small, number + leak_word+ c_word + '-poster.jpg', path, conf, filepath, failed_folder)
+def small_cover_check(path, number, cover_small, leak_word, c_word, conf: config.Config, filepath):
+    download_file_with_filename(cover_small, number + leak_word+ c_word + '-poster.jpg', path, conf, filepath)
     print('[+]Image Downloaded! ' + path + '/' + number + leak_word + c_word + '-poster.jpg')
 
 
@@ -351,7 +351,7 @@ def trimblank(s: str):
 # =====================资源下载部分===========================
 
 # path = examle:photo , video.in the Project Folder!
-def download_file_with_filename(url, filename, path, conf: config.Config, filepath, failed_folder):
+def download_file_with_filename(url, filename, path, conf: config.Config, filepath):
     configProxy = conf.proxy()
 
     for i in range(configProxy.retry):
@@ -397,14 +397,14 @@ def download_file_with_filename(url, filename, path, conf: config.Config, filepa
     moveFailedFolder(filepath)
     return
 
-def trailer_download(trailer, leak_word, c_word, number, path, filepath, conf: config.Config, failed_folder):
-    if download_file_with_filename(trailer, number + leak_word + c_word + '-trailer.mp4', path, conf, filepath, failed_folder) == 'failed':
+def trailer_download(trailer, leak_word, c_word, number, path, filepath, conf: config.Config):
+    if download_file_with_filename(trailer, number + leak_word + c_word + '-trailer.mp4', path, conf, filepath) == 'failed':
         return
     configProxy = conf.proxy()
     for i in range(configProxy.retry):
         if os.path.getsize(path+'/' + number + leak_word + c_word + '-trailer.mp4') == 0:
             print('[!]Video Download Failed! Trying again. [{}/3]', i + 1)
-            download_file_with_filename(trailer, number + leak_word + c_word + '-trailer.mp4', path, conf, filepath, failed_folder)
+            download_file_with_filename(trailer, number + leak_word + c_word + '-trailer.mp4', path, conf, filepath)
             continue
         else:
             break
@@ -413,19 +413,18 @@ def trailer_download(trailer, leak_word, c_word, number, path, filepath, conf: c
     print('[+]Video Downloaded!', path + '/' + number + leak_word + c_word + '-trailer.mp4')
 
 # 剧照下载成功，否则移动到failed
-def extrafanart_download(data, path, conf: config.Config, filepath, failed_folder):
+def extrafanart_download(data, path, conf: config.Config, filepath):
     j = 1
     path = path + '/' + conf.get_extrafanart()
     for url in data:
-        if download_file_with_filename(url, '/extrafanart-' + str(j)+'.jpg', path, conf, filepath, failed_folder) == 'failed':
+        if download_file_with_filename(url, '/extrafanart-' + str(j)+'.jpg', path, conf, filepath) == 'failed':
             moveFailedFolder(filepath)
             return
         configProxy = conf.proxy()
         for i in range(configProxy.retry):
             if os.path.getsize(path + '/extrafanart-' + str(j) + '.jpg') == 0:
                 print('[!]Image Download Failed! Trying again. [{}/3]', i + 1)
-                download_file_with_filename(url, '/extrafanart-' + str(j)+'.jpg', path, conf, filepath,
-                                            failed_folder)
+                download_file_with_filename(url, '/extrafanart-' + str(j)+'.jpg', path, conf, filepath)
                 continue
             else:
                 break
@@ -437,8 +436,8 @@ def extrafanart_download(data, path, conf: config.Config, filepath, failed_folde
 
 
 # 封面是否下载成功，否则移动到failed
-def image_download(cover, number, leak_word, c_word, path, conf: config.Config, filepath, failed_folder):
-    if download_file_with_filename(cover, number + leak_word + c_word + '-fanart.jpg', path, conf, filepath, failed_folder) == 'failed':
+def image_download(cover, number, leak_word, c_word, path, conf: config.Config, filepath):
+    if download_file_with_filename(cover, number + leak_word + c_word + '-fanart.jpg', path, conf, filepath) == 'failed':
         moveFailedFolder(filepath)
         return
 
@@ -446,7 +445,7 @@ def image_download(cover, number, leak_word, c_word, path, conf: config.Config, 
     for i in range(configProxy.retry):
         if os.path.getsize(path + '/' + number + leak_word + c_word + '-fanart.jpg') == 0:
             print('[!]Image Download Failed! Trying again. [{}/3]', i + 1)
-            download_file_with_filename(cover, number + leak_word + c_word + '-fanart.jpg', path, conf, filepath, failed_folder)
+            download_file_with_filename(cover, number + leak_word + c_word + '-fanart.jpg', path, conf, filepath)
             continue
         else:
             break
@@ -695,7 +694,7 @@ def paste_file_to_folder_mode2(filepath, path, multi_part, number, part, leak_wo
         print('[-]OS Error errno ' + oserr.errno)
         return
 
-def get_part(filepath, failed_folder):
+def get_part(filepath):
     try:
         if re.search('-CD\d+', filepath):
             return re.findall('-CD\d+', filepath)[0]
@@ -755,7 +754,7 @@ def core_main(file_path, number_th, conf: config.Config):
     # =======================================================================判断-C,-CD后缀
     if '-CD' in filepath or '-cd' in filepath:
         multi_part = 1
-        part = get_part(filepath, conf.failed_folder())
+        part = get_part(filepath)
     if '-c.' in filepath or '-C.' in filepath or '中文' in filepath or '字幕' in filepath:
         cn_sub = '1'
         c_word = '-C'  # 中文字幕影片后缀
@@ -793,21 +792,21 @@ def core_main(file_path, number_th, conf: config.Config):
 
         # 检查小封面, 如果image cut为3，则下载小封面
         if imagecut == 3:
-            small_cover_check(path, number,  json_data.get('cover_small'), leak_word, c_word, conf, filepath, conf.failed_folder())
+            small_cover_check(path, number,  json_data.get('cover_small'), leak_word, c_word, conf, filepath)
 
         # creatFolder会返回番号路径
-        image_download( json_data.get('cover'), number, leak_word, c_word, path, conf, filepath, conf.failed_folder())
+        image_download( json_data.get('cover'), number, leak_word, c_word, path, conf, filepath)
         try:
             # 下载预告片
             if json_data.get('trailer'):
-                trailer_download(json_data.get('trailer'), leak_word, c_word, number, path, filepath, conf, conf.failed_folder())
+                trailer_download(json_data.get('trailer'), leak_word, c_word, number, path, filepath, conf)
         except:
             pass
 
         try:
-            # 下载剧照 data, path, conf: config.Config, filepath, failed_folder
+            # 下载剧照 data, path, conf: config.Config, filepath
             if json_data.get('extrafanart'):
-                extrafanart_download(json_data.get('extrafanart'), path, conf, filepath, conf.failed_folder())
+                extrafanart_download(json_data.get('extrafanart'), path, conf, filepath)
         except:
             pass
         # 裁剪图
@@ -842,18 +841,18 @@ def core_main(file_path, number_th, conf: config.Config):
 
         # 检查小封面, 如果image cut为3，则下载小封面
         if imagecut == 3:
-            small_cover_check(path, number, json_data.get('cover_small'), leak_word, c_word, conf, filepath, conf.failed_folder())
+            small_cover_check(path, number, json_data.get('cover_small'), leak_word, c_word, conf, filepath)
 
         # creatFolder会返回番号路径
-        image_download(json_data.get('cover'), number, leak_word, c_word, path, conf, filepath, conf.failed_folder())
+        image_download(json_data.get('cover'), number, leak_word, c_word, path, conf, filepath)
 
         # 下载预告片
         if json_data.get('trailer'):
-            trailer_download(json_data.get('trailer'), leak_word, c_word, number, path, filepath, conf, conf.failed_folder())
+            trailer_download(json_data.get('trailer'), leak_word, c_word, number, path, filepath, conf)
 
-        # 下载剧照 data, path, conf: config.Config, filepath, failed_folder
+        # 下载剧照 data, path, conf: config.Config, filepath
         if json_data.get('extrafanart'):
-            extrafanart_download(json_data.get('extrafanart'), path, conf, filepath, conf.failed_folder())
+            extrafanart_download(json_data.get('extrafanart'), path, conf, filepath)
 
         # 裁剪图
         cutImage(imagecut, path, number, leak_word, c_word)


### PR DESCRIPTION
fix https://github.com/yoshiko2/AV_Data_Capture/issues/526
原先moveFailedFolder()的代码是有问题的，如果输入filepath是/down/abc-001/abc-001.mp4，得到的destination_path则是/down/abc-001/failed_folder，因此还是按AV_Data_Capture.py中create_data_and_move()的except中的处理代码为佳，无论config.ini中failed_output_folder是相对路径failed还是绝对路径/mnt/e/failed都能正确处理。
因此删除如下代码
```
root_path = str(pathlib.Path(filepath).parent)
file_name = pathlib.Path(filepath).name
destination_path = root_path + '/' + failed_folder + '/'
```
