### PR TITLE
tuple as return values in type annotation

### DIFF
--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import shutil
+import typing
 import urllib3
 
 import config
@@ -11,7 +12,6 @@ import time
 from ADC_function import get_html, is_link
 from number_parser import get_number
 from core import core_main
-import typing
 
 
 def check_update(local_version):

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -11,6 +11,7 @@ import time
 from ADC_function import get_html, is_link
 from number_parser import get_number
 from core import core_main
+import typing
 
 
 def check_update(local_version):
@@ -31,7 +32,7 @@ def check_update(local_version):
         print("[*]======================================================")
 
 
-def argparse_function(ver: str) -> [str, str, bool]:
+def argparse_function(ver: str) -> typing.Tuple[str, str, bool]:
     parser = argparse.ArgumentParser()
     parser.add_argument("file", default='', nargs='?', help="Single Movie file path.")
     parser.add_argument("-p","--path",default='',nargs='?',help="Analysis folder path.")


### PR DESCRIPTION
fix vscode report problem
`def argparse_function(ver: str) -> [str, str, bool]:`
List expression not allowed in type annotation
  Use List[T] to indicate a list type or Union[T1, T2] to indicate a union type