### PR TITLE
Fixing extrafanart downloading issue

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -71,5 +71,5 @@ water=2
 
 ; 剧照
 [extrafanart]
-switch=0
+switch=1
 extrafanart_folder=extrafanart

--- a/core.py
+++ b/core.py
@@ -418,14 +418,14 @@ def extrafanart_download(data, path, conf: config.Config, filepath):
     j = 1
     path = path + '/' + conf.get_extrafanart()
     for url in data:
-        if download_file_with_filename(url, '/extrafanart-' + str(j)+'.jpg', path, conf, filepath) == 'failed':
+        if download_file_with_filename(url, 'extrafanart-' + str(j)+'.jpg', path, conf, filepath) == 'failed':
             moveFailedFolder(filepath)
             return
         configProxy = conf.proxy()
         for i in range(configProxy.retry):
             if os.path.getsize(path + '/extrafanart-' + str(j) + '.jpg') == 0:
                 print('[!]Image Download Failed! Trying again. [{}/3]', i + 1)
-                download_file_with_filename(url, '/extrafanart-' + str(j)+'.jpg', path, conf, filepath)
+                download_file_with_filename(url, 'extrafanart-' + str(j)+'.jpg', path, conf, filepath)
                 continue
             else:
                 break


### PR DESCRIPTION
On windows, ` download_file_with_filename(url, 'extrafanart-' + str(j)+'.jpg', path, conf, filepath)` will download the extrafanart-{j}.jpg to the root of the current drive.

4.6.8 replaces path concatenation with os.path.join(), thus all the leading slashes in the sub-path should be removed.

Extrafanart downloading switch is turned on for future testing & updating.