### PR TITLE
Download extrafanart and trailer only once for multi-part movies

### DIFF
--- a/core.py
+++ b/core.py
@@ -802,7 +802,7 @@ def core_main(file_path, number_th, conf: config.Config):
             try:
                 # 下载预告片
                 if json_data.get('trailer'):
-                    trailer_download(json_data.get('trailer'), leak_word, c_word, number.split('-cd')[0], path, filepath, conf)
+                    trailer_download(json_data.get('trailer'), leak_word, c_word, number, path, filepath, conf)
             except:
                 pass
             try:

--- a/core.py
+++ b/core.py
@@ -797,19 +797,21 @@ def core_main(file_path, number_th, conf: config.Config):
 
         # creatFolder会返回番号路径
         image_download( json_data.get('cover'), number, leak_word, c_word, path, conf, filepath)
-        try:
-            # 下载预告片
-            if json_data.get('trailer'):
-                trailer_download(json_data.get('trailer'), leak_word, c_word, number, path, filepath, conf)
-        except:
-            pass
 
-        try:
-            # 下载剧照 data, path, conf: config.Config, filepath
-            if json_data.get('extrafanart'):
-                extrafanart_download(json_data.get('extrafanart'), path, conf, filepath)
-        except:
-            pass
+        if not multi_part or part.lower() == '-cd1':
+            try:
+                # 下载预告片
+                if json_data.get('trailer'):
+                    trailer_download(json_data.get('trailer'), leak_word, c_word, number.split('-cd')[0], path, filepath, conf)
+            except:
+                pass
+            try:
+                # 下载剧照 data, path, conf: config.Config, filepath
+                if json_data.get('extrafanart'):
+                    extrafanart_download(json_data.get('extrafanart'), path, conf, filepath)
+            except:
+                pass
+
         # 裁剪图
         cutImage(imagecut, path, number, leak_word, c_word)
 
@@ -847,13 +849,14 @@ def core_main(file_path, number_th, conf: config.Config):
         # creatFolder会返回番号路径
         image_download(json_data.get('cover'), number, leak_word, c_word, path, conf, filepath)
 
-        # 下载预告片
-        if json_data.get('trailer'):
-            trailer_download(json_data.get('trailer'), leak_word, c_word, number, path, filepath, conf)
+        if not multi_part or part.lower() == '-cd1':
+            # 下载预告片
+            if json_data.get('trailer'):
+                trailer_download(json_data.get('trailer'), leak_word, c_word, number, path, filepath, conf)
 
-        # 下载剧照 data, path, conf: config.Config, filepath
-        if json_data.get('extrafanart'):
-            extrafanart_download(json_data.get('extrafanart'), path, conf, filepath)
+            # 下载剧照 data, path, conf: config.Config, filepath
+            if json_data.get('extrafanart'):
+                extrafanart_download(json_data.get('extrafanart'), path, conf, filepath)
 
         # 裁剪图
         cutImage(imagecut, path, number, leak_word, c_word)


### PR DESCRIPTION
'-CD1' part tag is kept in the trailer's name so plex/jellyfin can bind it to the first part of the movie.