### PR TITLE
CLI version depends on python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Python 3.8
+      - name: Setup Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CLI 版本
 ![](https://img.shields.io/badge/build-passing-brightgreen.svg?style=flat)
 ![](https://img.shields.io/github/license/yoshiko2/av_data_capture.svg?style=flat)
 ![](https://img.shields.io/github/release/yoshiko2/av_data_capture.svg?style=flat)
-![](https://img.shields.io/badge/Python-3.8-yellow.svg?style=flat&logo=python)<br>
+![](https://img.shields.io/badge/Python-3.7-yellow.svg?style=flat&logo=python)<br>
 [GUI 版本](https://github.com/moyy996/AVDC)  
 ![](https://img.shields.io/badge/build-passing-brightgreen.svg?style=flat)
 ![](https://img.shields.io/github/license/moyy996/avdc.svg?style=flat)


### PR DESCRIPTION
Due to issue https://github.com/yoshiko2/AV_Data_Capture/issues/551, the CLI version now clearly depends on python version 3.7.