### PR TITLE
新功能:1.增量整理 2.保存运行及错误日志到目录

### DIFF
--- a/ADC_function.py
+++ b/ADC_function.py
@@ -467,6 +467,9 @@ def translate(
                 + src
         )
         result = get_html(url=url, return_type="object")
+        if not result.ok:
+            print('[-]Google-free translate web API calling failed.')
+            return ''
 
         translate_list = [i["trans"] for i in result.json()["sentences"]]
         trans_result = trans_result.join(translate_list)

--- a/ADC_function.py
+++ b/ADC_function.py
@@ -1,7 +1,7 @@
 from os import replace
 import requests
 import hashlib
-import pathlib
+from pathlib import Path
 import random
 import os.path
 import uuid
@@ -551,7 +551,7 @@ def load_cookies(filename):
 
 # 文件修改时间距此时的天数
 def file_modification_days(filename) -> int:
-    mfile = pathlib.Path(filename)
+    mfile = Path(filename)
     if not mfile.exists():
         return 9999
     mtime = int(mfile.stat().st_mtime)

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -143,11 +143,17 @@ def movie_lists(root, conf, regexstr):
             cliRE = re.compile(regexstr, re.IGNORECASE)
         except:
             pass
-    failed_list = []
+    failed_set = set()
     if main_mode == 3 or soft_link:
         try:
-            failed_list = open(os.path.join(conf.failed_folder(), 'failed_list.txt'),
-                'r', encoding='utf-8').read().splitlines()
+            with open(os.path.join(conf.failed_folder(), 'failed_list.txt'), 'r', encoding='utf-8')  as flt:
+                flist = flt.read().splitlines()
+                failed_set = set(flist)
+                flt.close()
+            if len(flist) != len(failed_set):
+                with open(os.path.join(conf.failed_folder(), 'failed_list.txt'), 'w', encoding='utf-8')  as flt:
+                    flt.writelines([line + '\n' for line in failed_set])
+                    flt.close()
         except:
             pass
     for current_dir, subdirs, files in os.walk(root, topdown=False):
@@ -158,7 +164,7 @@ def movie_lists(root, conf, regexstr):
             if not os.path.splitext(full_name)[1].upper() in file_type:
                 continue
             absf = os.path.abspath(full_name)
-            if absf in failed_list:
+            if absf in failed_set:
                 if debug:
                     print('[!]Skip failed file:', absf)
                 continue

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -304,6 +304,7 @@ if __name__ == '__main__':
         print('[+]Enable debug')
     if conf.soft_link():
         print('[!]Enable soft link')
+    print('[!]CmdLine:'," ".join(sys.argv[1:]))
 
     create_failed_folder(conf.failed_folder())
     start_time = time.time()

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 from ADC_function import  file_modification_days, get_html, is_link
 from number_parser import get_number
-from core import core_main
+from core import core_main, moveFailedFolder
 
 
 def check_update(local_version):
@@ -242,21 +242,10 @@ def create_data_and_move(file_path: str, c: config.Config, debug):
             print(f"[-] [{file_path}] ERROR:")
             print('[-]', err)
 
-            # 3.7.2 New: Move or not move to failed folder.
-            if c.failed_move() == False:
-                if c.soft_link():
-                    print("[-]Link {} to failed folder".format(file_path))
-                    os.symlink(file_path, os.path.join(conf.failed_folder(), file_name))
-            elif c.failed_move() == True:
-                if c.soft_link():
-                    print("[-]Link {} to failed folder".format(file_path))
-                    os.symlink(file_path, os.path.join(conf.failed_folder(), file_name))
-                else:
-                    try:
-                        print("[-]Move [{}] to failed folder".format(file_path))
-                        shutil.move(file_path, os.path.join(conf.failed_folder(), file_name))
-                    except Exception as err:
-                        print('[!]', err)
+            try:
+                moveFailedFolder(file_path, conf)
+            except Exception as err:
+                print('[!]', err)
 
 
 def create_data_and_move_with_custom_number(file_path: str, c: config.Config, custom_number):

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -126,6 +126,13 @@ def close_logfile(logdir: str):
             pass
 
 
+_print = print  # Hook print
+_stdout = sys.stdout
+def print(*args, **kw):
+    _print(*args, **kw)
+    if _stdout != sys.stdout:
+        sys.stdout.flush()
+
 
 # 重写视频文件扫描，消除递归，取消全局变量，新增失败文件列表跳过处理
 def movie_lists(root, conf, regexstr):
@@ -333,7 +340,6 @@ f'[!]运行模式：**维护模式**，本程序将在处理{count_all}个视频
             percentage = str(count / int(count_all) * 100)[:4] + '%'
             print('[!] - ' + percentage + ' [' + str(count) + '/' + count_all + '] -')
             create_data_and_move(movie_path, conf, conf.debug())
-            sys.stdout.flush()
             if count >= stop_count:
                 print("[!]Stop counter triggered!")
                 break

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -132,15 +132,17 @@ def movie_lists(root, conf):
     main_mode = conf.main_mode()
     debug = conf.debug()
     nfo_skip_days = conf.nfo_skip_days()
+    soft_link = conf.soft_link()
     total = []
     file_type = conf.media_type().upper().split(",")
     trailerRE = re.compile(r'-trailer\.', re.IGNORECASE)
-    try:
-        failed_list = open(os.path.join(conf.failed_folder(), 'failed_list.txt'),
-            'r', encoding='utf-8').read().splitlines()
-    except:
-        failed_list = []
-        pass
+    failed_list = []
+    if main_mode == 3 or soft_link:
+        try:
+            failed_list = open(os.path.join(conf.failed_folder(), 'failed_list.txt'),
+                'r', encoding='utf-8').read().splitlines()
+        except:
+            pass
     for current_dir, subdirs, files in os.walk(root, topdown=False):
         if current_dir in escape_folder:
             continue
@@ -159,7 +161,7 @@ def movie_lists(root, conf):
                     continue
             if (main_mode == 3 or not is_link(absf)) and not trailerRE.search(f):
                 total.append(absf)
-    if nfo_skip_days <= 0 or not conf.soft_link() or main_mode == 3:
+    if nfo_skip_days <= 0 or not soft_link or main_mode == 3:
         return total
     # 软连接方式，已经成功削刮的也需要从成功目录中检查.nfo更新天数，跳过N天内更新过的
     skip_numbers = set()

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -338,6 +338,7 @@ f'[!]运行模式：**维护模式**，本程序将在处理{count_all}个视频
             percentage = str(count / int(count_all) * 100)[:4] + '%'
             print('[!] - ' + percentage + ' [' + str(count) + '/' + count_all + '] -')
             create_data_and_move(movie_path, conf, conf.debug())
+            sys.stdout.flush()
             if count >= stop_count:
                 print("[!]Stop counter triggered!")
                 break

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -39,8 +39,10 @@ def argparse_function(ver: str) -> typing.Tuple[str, str, bool]:
     parser.add_argument("file", default='', nargs='?', help="Single Movie file path.")
     parser.add_argument("-p","--path",default='',nargs='?',help="Analysis folder path.")
     # parser.add_argument("-c", "--config", default='config.ini', nargs='?', help="The config file Path.")
-    parser.add_argument("-o","--log-dir",dest='logdir',default=os.path.join(Path.home(),'.avlogs'),nargs='?',
-        help="Duplicate from stdout and stderr to logfiles in log directory.")
+    parser.add_argument("-o","--log-dir",dest='logdir',
+        default=os.path.join(Path.home(),'.avlogs'),nargs='?',
+        help=f"Duplicate from stdout and stderr to logfiles in log directory. " +
+        "Default for current user is: " + os.path.join(Path.home(),'.avlogs'))
     parser.add_argument("-n", "--number", default='', nargs='?', help="Custom file number")
     parser.add_argument("-a", "--auto-exit", dest='autoexit', action="store_true",
                         help="Auto exit after program complete")

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -8,7 +8,7 @@ import typing
 import urllib3
 
 import config
-import datetime
+from datetime import datetime
 import time
 from pathlib import Path
 from ADC_function import  file_modification_days, get_html, is_link
@@ -101,7 +101,7 @@ def dupe_stdout_to_logfile(logdir: str):
         if not os.path.isdir(logdir):
             return
 
-    log_tmstr = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+    log_tmstr = datetime.now().strftime("%Y%m%dT%H%M%S")
     logfile = os.path.join(logdir, f'avdc_{log_tmstr}.txt')
     errlog = os.path.join(logdir, f'avdc_{log_tmstr}_err.txt')
 

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -39,7 +39,7 @@ def argparse_function(ver: str) -> typing.Tuple[str, str, bool]:
     parser.add_argument("file", default='', nargs='?', help="Single Movie file path.")
     parser.add_argument("-p","--path",default='',nargs='?',help="Analysis folder path.")
     # parser.add_argument("-c", "--config", default='config.ini', nargs='?', help="The config file Path.")
-    parser.add_argument("-o","--log-dir",dest='logdir',default='',nargs='?',
+    parser.add_argument("-o","--log-dir",dest='logdir',default=os.path.join(Path.home(),'.avlogs'),nargs='?',
         help="Duplicate from stdout and stderr to logfiles in log directory.")
     parser.add_argument("-n", "--number", default='', nargs='?', help="Custom file number")
     parser.add_argument("-a", "--auto-exit", dest='autoexit', action="store_true",

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -35,15 +35,16 @@ def check_update(local_version):
 
 
 def argparse_function(ver: str) -> typing.Tuple[str, str, bool]:
-    default_logdir = os.path.join(Path.home(),'.avlogs')
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("file", default='', nargs='?', help="Single Movie file path.")
     parser.add_argument("-p","--path",default='',nargs='?',help="Analysis folder path.")
     # parser.add_argument("-c", "--config", default='config.ini', nargs='?', help="The config file Path.")
+    default_logdir = os.path.join(Path.home(),'.avlogs')
     parser.add_argument("-o","--log-dir",dest='logdir',default=default_logdir,nargs='?',
-        help=f"""Duplicate from stdout and stderr to logfiles in log directory.
-Current user's default log folder is: {default_logdir}
-Use --log-dir= to turn off log feature.""")
+        help=f"""Duplicate stdout and stderr to logfiles
+in logging folder, default on.
+default for current user: {default_logdir}
+Use --log-dir= to turn off logging feature.""")
     parser.add_argument("-n", "--number", default='', nargs='?', help="Custom file number")
     parser.add_argument("-a", "--auto-exit", dest='autoexit', action="store_true",
                         help="Auto exit after program complete")

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -97,7 +97,7 @@ def dupe_stdout_to_logfile(logdir: str):
     if not isinstance(logdir, str) or len(logdir) == 0:
         return
     if not os.path.isdir(logdir):
-        os.mkdir(logdir)
+        os.makedirs(logdir)
         if not os.path.isdir(logdir):
             return
 

--- a/AV_Data_Capture.py
+++ b/AV_Data_Capture.py
@@ -35,14 +35,15 @@ def check_update(local_version):
 
 
 def argparse_function(ver: str) -> typing.Tuple[str, str, bool]:
-    parser = argparse.ArgumentParser()
+    default_logdir = os.path.join(Path.home(),'.avlogs')
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("file", default='', nargs='?', help="Single Movie file path.")
     parser.add_argument("-p","--path",default='',nargs='?',help="Analysis folder path.")
     # parser.add_argument("-c", "--config", default='config.ini', nargs='?', help="The config file Path.")
-    parser.add_argument("-o","--log-dir",dest='logdir',
-        default=os.path.join(Path.home(),'.avlogs'),nargs='?',
-        help=f"Duplicate from stdout and stderr to logfiles in log directory. " +
-        "Default for current user is: " + os.path.join(Path.home(),'.avlogs'))
+    parser.add_argument("-o","--log-dir",dest='logdir',default=default_logdir,nargs='?',
+        help=f"""Duplicate from stdout and stderr to logfiles in log directory.
+Current user's default log folder is: {default_logdir}
+Use --log-dir= to turn off log feature.""")
     parser.add_argument("-n", "--number", default='', nargs='?', help="Custom file number")
     parser.add_argument("-a", "--auto-exit", dest='autoexit', action="store_true",
                         help="Auto exit after program complete")

--- a/WebCrawler/__init__.py
+++ b/WebCrawler/__init__.py
@@ -126,8 +126,8 @@ def get_data_from_json(file_number, conf: config.Config):  # 从JSON返回元数
 
     # Return if data not found in all sources
     if not json_data:
-        print('[-]Movie Data not found!')
-        return
+        print('[-]Movie Number not found!')
+        return None
 
     # ================================================网站规则添加结束================================================
 
@@ -165,8 +165,8 @@ def get_data_from_json(file_number, conf: config.Config):  # 从JSON返回元数
     actor = str(actor_list).strip("[ ]").replace("'", '').replace(" ", '')
 
     if title == '' or number == '':
-        print('[-]Movie Data not found!')
-        return
+        print('[-]Movie Number or Title not found!')
+        return None
 
     # if imagecut == '3':
     #     DownloadFileWithFilename()

--- a/config.ini
+++ b/config.ini
@@ -74,3 +74,12 @@ water=2
 [extrafanart]
 switch=0
 extrafanart_folder=extrafanart
+
+; 整理模式 ([common] main_mode=3)
+[main_mode_3]
+; 整理时跳过最近(默认:30)天新修改过的.NFO，可避免反复整理靠前的文件，0为总是整理全部文件
+nfo_skip_days=30
+; 整理文件时达到指定个数即停止，配合google free翻译使用时，避免触发翻译次数上限导致的翻译失败，0为不限制
+mode3_stop_counter=0
+; 以上两个参数配合使用，可以用于定时执行的计划任务，例如将数千个视频文件的元数据在几周内分批更新
+; 程序启动参数'-o 日志目录'则可生成日志，检查几周内日志可找出失败文件手工处理 

--- a/config.ini
+++ b/config.ini
@@ -10,6 +10,12 @@ multi_threading=1
 ;actor_gender value: female(♀) or male(♂) or both(♀ ♂) or all(♂ ♀ ⚧)
 actor_gender=female
 del_empty_folder=1
+; 跳过最近(默认:30)天新修改过的.NFO，可避免整理模式(main_mode=3)和软连接(soft_link=0)时
+; 反复刮削靠前的视频文件，0为处理所有视频文件
+nfo_skip_days=30
+; 处理完多少个视频文件后停止，0为处理所有视频文件
+stop_counter=0
+; 以上两个参数配合使用可以以多次少量的方式刮削或整理数千个文件而不触发翻译或元数据站封禁
 
 [proxy]
 ;proxytype: http or socks5 or socks5h switch: 0 1
@@ -75,11 +81,3 @@ water=2
 switch=0
 extrafanart_folder=extrafanart
 
-; 整理模式 ([common] main_mode=3)
-[main_mode_3]
-; 整理时跳过最近(默认:30)天新修改过的.NFO，可避免反复整理靠前的文件，0为总是整理全部文件
-nfo_skip_days=30
-; 整理文件时达到指定个数即停止，配合google free翻译使用时，避免触发翻译次数上限导致的翻译失败，0为不限制
-mode3_stop_counter=0
-; 以上两个参数配合使用，可以用于定时执行的计划任务，例如将数千个视频文件的元数据在几周内分批更新
-; 程序启动参数'-o 日志目录'则可生成日志，检查几周内日志可找出失败文件手工处理 

--- a/config.py
+++ b/config.py
@@ -54,6 +54,16 @@ class Config:
         return self.conf.getboolean("common", "multi_threading")
     def del_empty_folder(self) -> bool:
         return self.conf.getboolean("common", "del_empty_folder")
+    def nfo_skip_days(self) -> int:
+        try:
+            return self.conf.getint("common", "nfo_skip_days")
+        except:
+            return 30
+    def stop_counter(self) -> int:
+        try:
+            return self.conf.getint("common", "stop_counter")
+        except:
+            return 0
     def is_transalte(self) -> bool:
         return self.conf.getboolean("transalte", "switch")
     def is_trailer(self) -> bool:
@@ -149,18 +159,6 @@ class Config:
     def debug(self) -> bool:
         return self.conf.getboolean("debug_mode", "switch")
 
-    def mode3_nfo_skip_days(self) -> int:
-        try:
-            return self.conf.getint("main_mode_3", "nfo_skip_days")
-        except:
-            return 30
-
-    def mode3_stop_counter(self) -> int:
-        try:
-            return self.conf.getint("main_mode_3", "mode3_stop_counter")
-        except:
-            return 0
-
     @staticmethod
     def _exit(sec: str) -> None:
         print("[-] Read config error! Please check the {} section in config.ini", sec)
@@ -183,6 +181,8 @@ class Config:
         # actor_gender value: female or male or both or all(含人妖)
         conf.set(sec1, "actor_gender", "female")
         conf.set(sec1, "del_empty_folder", "1")
+        conf.set(sec1, "nfo_skip_days", 30)
+        conf.set(sec1, "stop_counter", 0)
 
         sec2 = "proxy"
         conf.add_section(sec2)
@@ -248,14 +248,7 @@ class Config:
         conf.set(sec13, "switch", 1)
         conf.set(sec13, "extrafanart_folder", "extrafanart")
 
-        sec14 = "main_mode_3"
-        conf.add_section(sec14)
-        conf.set(sec14, "nfo_skip_days", 30)
-        conf.set(sec14, "mode3_stop_counter", 0)
-
         return conf
-
-
 
 
 class IniProxy():

--- a/config.py
+++ b/config.py
@@ -149,6 +149,18 @@ class Config:
     def debug(self) -> bool:
         return self.conf.getboolean("debug_mode", "switch")
 
+    def mode3_nfo_skip_days(self) -> int:
+        try:
+            return self.conf.getint("main_mode_3", "nfo_skip_days")
+        except:
+            return 30
+
+    def mode3_stop_counter(self) -> int:
+        try:
+            return self.conf.getint("main_mode_3", "mode3_stop_counter")
+        except:
+            return 0
+
     @staticmethod
     def _exit(sec: str) -> None:
         print("[-] Read config error! Please check the {} section in config.ini", sec)
@@ -235,6 +247,11 @@ class Config:
         conf.add_section(sec13)
         conf.set(sec13, "switch", 1)
         conf.set(sec13, "extrafanart_folder", "extrafanart")
+
+        sec14 = "main_mode_3"
+        conf.add_section(sec14)
+        conf.set(sec14, "nfo_skip_days", 30)
+        conf.set(sec14, "mode3_stop_counter", 0)
 
         return conf
 

--- a/config.py
+++ b/config.py
@@ -2,15 +2,29 @@ import os
 import sys
 import configparser
 import codecs
+from pathlib import Path
 
 class Config:
     def __init__(self, path: str = "config.ini"):
-        if os.path.exists(path):
+        path_search_order = [
+            path,
+            "./config.ini",
+            os.path.join(Path.home(), "avdc.ini"),
+            os.path.join(Path.home(), ".avdc.ini"),
+            os.path.join(Path.home(), ".avdc/config.ini"),
+            os.path.join(Path.home(), ".config/avdc/config.ini")
+        ]
+        ini_path = None
+        for p in path_search_order:
+            if os.path.exists(p):
+                ini_path = p
+                break
+        if ini_path:
             self.conf = configparser.ConfigParser()
             try:
-                self.conf.read(path, encoding="utf-8-sig")
+                self.conf.read(ini_path, encoding="utf-8-sig")
             except:
-                self.conf.read(path, encoding="utf-8")
+                self.conf.read(ini_path, encoding="utf-8")
         else:
             print("[-]Config file not found!")
             sys.exit(2)

--- a/core.py
+++ b/core.py
@@ -55,8 +55,9 @@ def get_info(json_data):  # 返回json里的数据
 
 
 def small_cover_check(path, number, cover_small, leak_word, c_word, conf: config.Config, filepath):
-    download_file_with_filename(cover_small, number + leak_word+ c_word + '-poster.jpg', path, conf, filepath)
-    print('[+]Image Downloaded! ' + path + '/' + number + leak_word + c_word + '-poster.jpg')
+    filename = f"{number}{leak_word}{c_word}-poster.jpg"
+    download_file_with_filename(cover_small, filename, path, conf, filepath)
+    print('[+]Image Downloaded! ' + os.path.join(str(path), filename))
 
 
 def create_folder(json_data, conf: config.Config):  # 创建文件夹
@@ -162,44 +163,48 @@ def trailer_download(trailer, leak_word, c_word, number, path, filepath, conf: c
 # 剧照下载成功，否则移动到failed
 def extrafanart_download(data, path, conf: config.Config, filepath):
     j = 1
-    path = path + '/' + conf.get_extrafanart()
+    path = os.path.join(str(path), conf.get_extrafanart())
     for url in data:
-        if download_file_with_filename(url, 'extrafanart-' + str(j)+'.jpg', path, conf, filepath) == 'failed':
+        jpg_filename = f'extrafanart-{j}.jpg'
+        jpg_fullpath = os.path.join(str(path), jpg_filename)
+        if download_file_with_filename(url, jpg_filename, path, conf, filepath) == 'failed':
             moveFailedFolder(filepath)
             return
         configProxy = conf.proxy()
         for i in range(configProxy.retry):
-            if os.path.getsize(path + '/extrafanart-' + str(j) + '.jpg') == 0:
+            if os.path.getsize(jpg_fullpath) == 0:
                 print('[!]Image Download Failed! Trying again. [{}/3]', i + 1)
-                download_file_with_filename(url, 'extrafanart-' + str(j)+'.jpg', path, conf, filepath)
+                download_file_with_filename(url, jpg_filename, path, conf, filepath)
                 continue
             else:
                 break
-        if os.path.getsize(path + '/extrafanart-' + str(j) + '.jpg') == 0:
+        if os.path.getsize(jpg_fullpath) == 0:
             return
-        print('[+]Image Downloaded!', path + '/extrafanart-' + str(j) + '.jpg')
+        print('[+]Image Downloaded!', jpg_fullpath)
         j += 1
 
 
 
 # 封面是否下载成功，否则移动到failed
 def image_download(cover, number, leak_word, c_word, path, conf: config.Config, filepath):
-    if download_file_with_filename(cover, number + leak_word + c_word + '-fanart.jpg', path, conf, filepath) == 'failed':
+    filename = f"{number}{leak_word}{c_word}-fanart.jpg"
+    full_filepath = os.path.join(str(path), filename)
+    if download_file_with_filename(cover, filename, path, conf, filepath) == 'failed':
         moveFailedFolder(filepath)
         return
 
     configProxy = conf.proxy()
     for i in range(configProxy.retry):
-        if os.path.getsize(path + '/' + number + leak_word + c_word + '-fanart.jpg') == 0:
+        if os.path.getsize(full_filepath) == 0:
             print('[!]Image Download Failed! Trying again. [{}/3]', i + 1)
-            download_file_with_filename(cover, number + leak_word + c_word + '-fanart.jpg', path, conf, filepath)
+            download_file_with_filename(cover, filename, path, conf, filepath)
             continue
         else:
             break
-    if os.path.getsize(path + '/' + number + leak_word + c_word + '-fanart.jpg') == 0:
+    if os.path.getsize(full_filepath) == 0:
         return
-    print('[+]Image Downloaded!', path + '/' + number + leak_word + c_word + '-fanart.jpg')
-    shutil.copyfile(path + '/' + number + leak_word + c_word + '-fanart.jpg',path + '/' + number + leak_word + c_word + '-thumb.jpg')
+    print('[+]Image Downloaded!', full_filepath)
+    shutil.copyfile(full_filepath, os.path.join(str(path), f"{number}{leak_word}{c_word}-thumb.jpg"))
 
 
 def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, filepath, tag, actor_list, liuchu, uncensored, conf):
@@ -281,21 +286,21 @@ def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, f
 
 
 def cutImage(imagecut, path, number, leak_word, c_word):
+    fullpath_noext = os.path.join(path, f"{number}{leak_word}{c_word}")
     if imagecut == 1: # 剪裁大封面
         try:
-            img = Image.open(path + '/' + number + leak_word + c_word + '-fanart.jpg')
+            img = Image.open(fullpath_noext + '-fanart.jpg')
             imgSize = img.size
             w = img.width
             h = img.height
             img2 = img.crop((w / 1.9, 0, w, h))
-            img2.save(path + '/' + number + leak_word + c_word + '-poster.jpg')
-            print('[+]Image Cutted!     ' + path + '/' + number + leak_word + c_word + '-poster.jpg')
+            img2.save(fullpath_noext + '-poster.jpg')
+            print('[+]Image Cutted!     ' + fullpath_noext + '-poster.jpg')
         except:
             print('[-]Cover cut failed!')
     elif imagecut == 0: # 复制封面
-        shutil.copyfile(path + '/' + number + leak_word + c_word + '-fanart.jpg',
-                        path + '/' + number + leak_word + c_word + '-poster.jpg')
-        print('[+]Image Copyed!     ' + path + '/' + number + leak_word + c_word + '-poster.jpg')
+        shutil.copyfile(fullpath_noext + '-fanart.jpg', fullpath_noext + '-poster.jpg')
+        print('[+]Image Copyed!     ' + fullpath_noext + '-poster.jpg')
 
 # 此函数从gui版copy过来用用
 # 参数说明

--- a/core.py
+++ b/core.py
@@ -28,13 +28,18 @@ def moveFailedFolder(filepath, conf):
     # 模式3或软连接，改为维护一个失败列表，启动扫描时加载用于排除该路径，以免反复处理
     # 原先的创建软连接到失败目录，并不直观，不方便找到失败文件位置，不如直接记录该文件路径
     if conf.main_mode() == 3 or soft_link:
-        open(os.path.join(failed_folder, 'failed_list.txt'), 'a', encoding='utf-8'
-            ).write(f'{filepath}\n').close()
-        print('[-]Add to failed list file')
+        with open(os.path.join(failed_folder, 'failed_list.txt'), 'a', encoding='utf-8') as flt:
+            flt.write(f'{filepath}\n')
+            flt.close()
+        print('[-]Add to failed list file, see failed_list.txt')
     elif conf.failed_move() and not soft_link:
-        file_name = os.path.basename(filepath)
-        print('[-]Move to Failed output folder')
-        shutil.move(filepath, os.path.join(failed_folder, file_name))
+        failed_name = os.path.join(failed_folder, os.path.basename(filepath))
+        print('[-]Move to Failed output folder, see where_was_i_before_being_moved.txt')
+        with open(os.path.join(failed_folder, 'where_was_i_before_being_moved.txt'), 'a',
+                 encoding='utf-8') as wwibbmt:
+            wwibbmt.write(f'FROM[{filepath}]TO[{failed_name}]\n')
+            wwibbmt.close()
+        shutil.move(filepath, failed_name)
 
 
 def get_info(json_data):  # 返回json里的数据
@@ -418,7 +423,7 @@ def paste_file_to_folder(filepath, path, number, leak_word, c_word, conf: config
         print('[-]Error! Please run as administrator!')
         return
     except OSError as oserr:
-        print('[-]OS Error errno ' + oserr.errno)
+        print(f'[-]OS Error errno {oserr.errno}')
         return
 
 
@@ -448,7 +453,7 @@ def paste_file_to_folder_mode2(filepath, path, multi_part, number, part, leak_wo
         print('[-]Error! Please run as administrator!')
         return
     except OSError as oserr:
-        print('[-]OS Error errno ' + oserr.errno)
+        print(f'[-]OS Error errno  {oserr.errno}')
         return
 
 def get_part(filepath, conf):

--- a/core.py
+++ b/core.py
@@ -9,6 +9,7 @@ import sys
 
 from PIL import Image
 from io import BytesIO
+from pathlib import Path
 
 from ADC_function import *
 from WebCrawler import get_data_from_json
@@ -201,13 +202,17 @@ def image_download(cover, number, leak_word, c_word, path, conf: config.Config, 
     shutil.copyfile(path + '/' + number + leak_word + c_word + '-fanart.jpg',path + '/' + number + leak_word + c_word + '-thumb.jpg')
 
 
-def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, filepath, failed_folder, tag, actor_list, liuchu, uncensored):
+def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, filepath, tag, actor_list, liuchu, uncensored, conf):
     title, studio, year, outline, runtime, director, actor_photo, release, number, cover, trailer, website, series, label = get_info(json_data)
-
+    failed_folder = conf.failed_folder()
+    if conf.main_mode() == 3:  # 模式3下，由于视频文件不做任何改变，.nfo文件必须和视频文件名称除后缀外完全一致，KODI等软件方可支持
+        nfo_path = str(Path(filepath).with_suffix('.nfo'))
+    else:
+        nfo_path = os.path.join(path,f"{number}{part}{leak_word}{c_word}.nfo")
     try:
         if not os.path.exists(path):
             os.makedirs(path)
-        with open(path + "/" + number + part + leak_word + c_word + ".nfo", "wt", encoding='UTF-8') as code:
+        with open(nfo_path, "wt", encoding='UTF-8') as code:
             print('<?xml version="1.0" encoding="UTF-8" ?>', file=code)
             print("<movie>", file=code)
             print(" <title>" + naming_rule + "</title>", file=code)
@@ -262,7 +267,7 @@ def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, f
                 print("  <trailer>" + trailer + "</trailer>", file=code)
             print("  <website>" + website + "</website>", file=code)
             print("</movie>", file=code)
-            print("[+]Wrote!            " + path + "/" + number + part + leak_word + c_word + ".nfo")
+            print("[+]Wrote!            " + nfo_path)
     except IOError as e:
         print("[-]Write Failed!")
         print(e)
@@ -562,7 +567,7 @@ def core_main(file_path, number_th, conf: config.Config):
         cutImage(imagecut, path, number, leak_word, c_word)
 
         # 打印文件
-        print_files(path, leak_word, c_word,  json_data.get('naming_rule'), part, cn_sub, json_data, filepath, conf.failed_folder(), tag,  json_data.get('actor_list'), liuchu, uncensored)
+        print_files(path, leak_word, c_word,  json_data.get('naming_rule'), part, cn_sub, json_data, filepath, tag,  json_data.get('actor_list'), liuchu, uncensored, conf)
 
         # 移动文件
         paste_file_to_folder(filepath, path, number, leak_word, c_word, conf)
@@ -608,8 +613,8 @@ def core_main(file_path, number_th, conf: config.Config):
         cutImage(imagecut, path, number, leak_word, c_word)
 
         # 打印文件
-        print_files(path, leak_word, c_word, json_data.get('naming_rule'), part, cn_sub, json_data, filepath, conf.failed_folder(),
-                    tag, json_data.get('actor_list'), liuchu, uncensored)
+        print_files(path, leak_word, c_word, json_data.get('naming_rule'), part, cn_sub, json_data, filepath,
+                    tag, json_data.get('actor_list'), liuchu, uncensored, conf)
 
         poster_path = os.path.join(path, f"{number}{leak_word}{c_word}-poster.jpg")
         thumb_path = os.path.join(path, f"{number}{leak_word}{c_word}-thumb.jpg")

--- a/core.py
+++ b/core.py
@@ -10,6 +10,7 @@ import sys
 from PIL import Image
 from io import BytesIO
 from pathlib import Path
+from datetime import datetime
 
 from ADC_function import *
 from WebCrawler import get_data_from_json
@@ -28,16 +29,18 @@ def moveFailedFolder(filepath, conf):
     # 模式3或软连接，改为维护一个失败列表，启动扫描时加载用于排除该路径，以免反复处理
     # 原先的创建软连接到失败目录，并不直观，不方便找到失败文件位置，不如直接记录该文件路径
     if conf.main_mode() == 3 or soft_link:
-        with open(os.path.join(failed_folder, 'failed_list.txt'), 'a', encoding='utf-8') as flt:
+        ftxt = os.path.join(failed_folder, 'failed_list.txt')
+        print("[-]Add to Failed List file, see '%s'" % ftxt)
+        with open(ftxt, 'a', encoding='utf-8') as flt:
             flt.write(f'{filepath}\n')
             flt.close()
-        print('[-]Add to failed list file, see failed_list.txt')
     elif conf.failed_move() and not soft_link:
         failed_name = os.path.join(failed_folder, os.path.basename(filepath))
-        print('[-]Move to Failed output folder, see where_was_i_before_being_moved.txt')
-        with open(os.path.join(failed_folder, 'where_was_i_before_being_moved.txt'), 'a',
-                 encoding='utf-8') as wwibbmt:
-            wwibbmt.write(f'FROM[{filepath}]TO[{failed_name}]\n')
+        mtxt = os.path.join(failed_folder, 'where_was_i_before_being_moved.txt')
+        print("'[-]Move to Failed output folder, see '%s'" % mtxt)
+        with open(mtxt, 'a', encoding='utf-8') as wwibbmt:
+            tmstr = datetime.now().strftime("%Y-%m-%d %H:%M")
+            wwibbmt.write(f'{tmstr} FROM[{filepath}]TO[{failed_name}]\n')
             wwibbmt.close()
         shutil.move(filepath, failed_name)
 

--- a/core.py
+++ b/core.py
@@ -57,7 +57,7 @@ def get_info(json_data):  # 返回json里的数据
 def small_cover_check(path, number, cover_small, leak_word, c_word, conf: config.Config, filepath):
     filename = f"{number}{leak_word}{c_word}-poster.jpg"
     download_file_with_filename(cover_small, filename, path, conf, filepath)
-    print('[+]Image Downloaded! ' + os.path.join(str(path), filename))
+    print('[+]Image Downloaded! ' + os.path.join(path, filename))
 
 
 def create_folder(json_data, conf: config.Config):  # 创建文件夹
@@ -114,7 +114,7 @@ def download_file_with_filename(url, filename, path, conf: config.Config, filepa
                 if r == '':
                     print('[-]Movie Data not found!')
                     return
-                with open(os.path.join(str(path), filename), "wb") as code:
+                with open(os.path.join(path, filename), "wb") as code:
                     code.write(r.content)
                 return
             else:
@@ -126,7 +126,7 @@ def download_file_with_filename(url, filename, path, conf: config.Config, filepa
                 if r == '':
                     print('[-]Movie Data not found!')
                     return
-                with open(os.path.join(str(path), filename), "wb") as code:
+                with open(os.path.join(path, filename), "wb") as code:
                     code.write(r.content)
                 return
         except requests.exceptions.RequestException:
@@ -163,10 +163,10 @@ def trailer_download(trailer, leak_word, c_word, number, path, filepath, conf: c
 # 剧照下载成功，否则移动到failed
 def extrafanart_download(data, path, conf: config.Config, filepath):
     j = 1
-    path = os.path.join(str(path), conf.get_extrafanart())
+    path = os.path.join(path, conf.get_extrafanart())
     for url in data:
         jpg_filename = f'extrafanart-{j}.jpg'
-        jpg_fullpath = os.path.join(str(path), jpg_filename)
+        jpg_fullpath = os.path.join(path, jpg_filename)
         if download_file_with_filename(url, jpg_filename, path, conf, filepath) == 'failed':
             moveFailedFolder(filepath)
             return
@@ -188,7 +188,7 @@ def extrafanart_download(data, path, conf: config.Config, filepath):
 # 封面是否下载成功，否则移动到failed
 def image_download(cover, number, leak_word, c_word, path, conf: config.Config, filepath):
     filename = f"{number}{leak_word}{c_word}-fanart.jpg"
-    full_filepath = os.path.join(str(path), filename)
+    full_filepath = os.path.join(path, filename)
     if download_file_with_filename(cover, filename, path, conf, filepath) == 'failed':
         moveFailedFolder(filepath)
         return
@@ -204,7 +204,7 @@ def image_download(cover, number, leak_word, c_word, path, conf: config.Config, 
     if os.path.getsize(full_filepath) == 0:
         return
     print('[+]Image Downloaded!', full_filepath)
-    shutil.copyfile(full_filepath, os.path.join(str(path), f"{number}{leak_word}{c_word}-thumb.jpg"))
+    shutil.copyfile(full_filepath, os.path.join(path, f"{number}{leak_word}{c_word}-thumb.jpg"))
 
 
 def print_files(path, leak_word, c_word, naming_rule, part, cn_sub, json_data, filepath, tag, actor_list, liuchu, uncensored, conf):
@@ -593,8 +593,7 @@ def core_main(file_path, number_th, conf: config.Config):
             add_mark(poster_path, thumb_path, cn_sub, leak, uncensored, conf)
 
     elif conf.main_mode() == 3:
-        path = file_path.rsplit('/', 1)[0]
-        path = path.rsplit('\\', 1)[0]
+        path = str(Path(file_path).parent)
         if multi_part == 1:
             number += part  # 这时number会被附加上CD1后缀
 

--- a/core.py
+++ b/core.py
@@ -28,9 +28,8 @@ def moveFailedFolder(filepath, conf):
     # 模式3或软连接，改为维护一个失败列表，启动扫描时加载用于排除该路径，以免反复处理
     # 原先的创建软连接到失败目录，并不直观，不方便找到失败文件位置，不如直接记录该文件路径
     if conf.main_mode() == 3 or soft_link:
-        with open(os.path.join(failed_folder, 'failed_list.txt'), 'a', encoding='utf-8') as m3f:
-            m3f.write(f'{filepath}\n')
-            m3f.close()
+        open(os.path.join(failed_folder, 'failed_list.txt'), 'a', encoding='utf-8'
+            ).write(f'{filepath}\n').close()
         print('[-]Add to failed list file')
     elif conf.failed_move() and not soft_link:
         file_name = os.path.basename(filepath)


### PR DESCRIPTION
```ini
[common]
; 跳过最近(默认:30)天新修改过的.NFO，可避免整理模式(main_mode=3)和软连接(soft_link=0)时
; 反复刮削靠前的视频文件，0为处理所有视频文件
nfo_skip_days=30
; 处理完多少个视频文件后停止，0为处理所有视频文件
stop_counter=0
; 以上两个参数配合使用可以以多次少量的方式刮削或整理数千个文件而不触发翻译或元数据站封禁
```

程序启动参数'-o 日志目录'则可生成日志，检查几周内日志可找出失败文件手工处理。
最近更新：已改为默认开启，避免忘记开启日志而无法找回错误改名或移动的文件，默认日志目录以及关闭日志的方法可通过运行程序时带参数`--help`来查看。
