### PR TITLE
javdb*.json path search order

### DIFF
--- a/ADC_function.py
+++ b/ADC_function.py
@@ -590,10 +590,26 @@ def is_uncensored(number):
 # 从网站登录后，通过浏览器插件(CookieBro或EdittThisCookie)或者直接在地址栏网站链接信息处都可以复制或者导出cookie内容，
 # 并填写到以上json文件的相应字段中
 def load_cookies(filename):
+    filename = os.path.basename(filename)
+    if not len(filename):
+        return None, None
+    path_search_order = [
+        f"./{filename}",
+        os.path.join(Path.home(), filename),
+        os.path.join(Path.home(), f".avdc/{filename}"),
+        os.path.join(Path.home(), f".local/share/avdc/{filename}")
+]
+    cookies_filename = None
+    for p in path_search_order:
+        if os.path.exists(p):
+            cookies_filename = p
+            break
+    if not cookies_filename:
+        return None, None
     try:
-        return json.load(open(filename))
+        return json.load(open(cookies_filename)), cookies_filename
     except:
-        return None
+        return None, None
 
 # 文件修改时间距此时的天数
 def file_modification_days(filename) -> int:

--- a/ADC_function.py
+++ b/ADC_function.py
@@ -602,7 +602,7 @@ def load_cookies(filename):
     cookies_filename = None
     for p in path_search_order:
         if os.path.exists(p):
-            cookies_filename = p
+            cookies_filename = os.path.abspath(p)
             break
     if not cookies_filename:
         return None, None

--- a/WebCrawler/javdb.py
+++ b/WebCrawler/javdb.py
@@ -220,10 +220,10 @@ def main(number):
         # 不加载过期的cookie，javdb登录界面显示为7天免登录，故假定cookie有效期为7天
         cdays = file_modification_days(cookie_json)
         if cdays < 7:
-            javdb_cookies = load_cookies(cookie_json)
+            javdb_cookies, cookies_filepath = load_cookies(cookie_json)
         elif cdays != 9999:
-            print('[!]Cookies file ' + cookie_json + ' was updated ' + str(cdays) +
-                  ' days ago, it will not be used for HTTP requests.')
+            print(
+f'[!]Cookies file {cookies_filepath} was updated {cdays} days ago, it will not be used for HTTP requests.')
 
         try:
             javdb_url = 'https://' + javdb_site + '.com/search?q=' + number + '&f=all'

--- a/core.py
+++ b/core.py
@@ -29,14 +29,14 @@ def moveFailedFolder(filepath, conf):
     # 模式3或软连接，改为维护一个失败列表，启动扫描时加载用于排除该路径，以免反复处理
     # 原先的创建软连接到失败目录，并不直观，不方便找到失败文件位置，不如直接记录该文件路径
     if conf.main_mode() == 3 or soft_link:
-        ftxt = os.path.join(failed_folder, 'failed_list.txt')
+        ftxt = os.path.abspath(os.path.join(failed_folder, 'failed_list.txt'))
         print("[-]Add to Failed List file, see '%s'" % ftxt)
         with open(ftxt, 'a', encoding='utf-8') as flt:
             flt.write(f'{filepath}\n')
             flt.close()
     elif conf.failed_move() and not soft_link:
         failed_name = os.path.join(failed_folder, os.path.basename(filepath))
-        mtxt = os.path.join(failed_folder, 'where_was_i_before_being_moved.txt')
+        mtxt = os.path.abspath(os.path.join(failed_folder, 'where_was_i_before_being_moved.txt'))
         print("'[-]Move to Failed output folder, see '%s'" % mtxt)
         with open(mtxt, 'a', encoding='utf-8') as wwibbmt:
             tmstr = datetime.now().strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
与config.ini类似，为javdb9.json和javdb30.json提供路径搜索次序，按以下次序查找文件，以找到的第一个文件为准，不再向下尝试。
```
./javdb9.json
~/javdb9.json
~/.avdc/javdb9.json
~/.local/share/avdc/javdb9.json
```